### PR TITLE
Add document about vim-go-impl to use `impl` in Vim editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ func (f *File) Close() error {
 }
 
 ```
+
+You can use `impl` from Vim with [vim-go-impl](https://github.com/rhysd/vim-go-impl)


### PR DESCRIPTION
Hi, thank you for very handy tool.

I implemented [vim-go-impl](https://github.com/rhysd/vim-go-impl) for Vim users to use `impl` and added document about it.
