### PR TITLE
README: Mention the import path of Go package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 `impl` generates method stubs for implementing an interface.
 
+```bash
+go get -u github.com/josharian/impl
+```
+
 Sample usage:
 
 ```bash


### PR DESCRIPTION
Not mentioning the import path in the README makes it hard to know if there's a vanity import path that should be used, or if it's just the github URL. In this case, looking at the source code to check if there's an `// import` comment is not helpful to determine the import path, since there is no such comment.

Most Go packages mention their import path in the README, so it's quite jarring to stumble upon one that doesn't.

Addresses point mentioned in https://github.com/josharian/impl/commit/95c3a3657029c2d320fa2d9ca781e3b46d638955#commitcomment-16526615.