### PR TITLE
Pass a less-bogus source filename to goimports.

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -42,7 +42,7 @@ func findInterface(iface string) (path string, id string, err error) {
 
 	// Let goimports do the heavy lifting.
 	src := []byte("package hack\n" + "var i " + iface)
-	imp, err := imports.Process("", src, nil)
+	imp, err := imports.Process(".", src, nil)
 	if err != nil {
 		return "", "", fmt.Errorf("couldn't parse interface: %s", iface)
 	}


### PR DESCRIPTION
This fixes impl on Windows.
filepath.Abs("") fails there, where on other platforms it returns cwd.
It should be alright, however, since it's not actually writing back to the source file and only uses it to get the absolute path as an import basis.

```
(godebug) l

        if len(strings.Fields(iface)) != 1 {
                return "", "", fmt.Errorf("couldn't parse interface: %s", iface)
        }

-->     _ = "breakpoint"
        // Let goimports do the heavy lifting.
        src := []byte("package hack\n" + "var i " + iface)
        imp, err := imports.Process("", src, nil)
        if err != nil {

(godebug) n
-> src := []byte("package hack\n" + "var i " + iface)
(godebug) n
-> imp, err := imports.Process("", src, nil)
(godebug) s
-> if opt == nil {
(godebug) n
-> opt = &Options{Comments: true, TabIndent: true, TabWidth: 8}
(godebug) n
-> fileSet := token.NewFileSet()
(godebug) n
-> file, adjust, err := parse(fileSet, filename, src, opt)
(godebug) n
-> if err != nil {
(godebug) n
-> if !opt.FormatOnly {
(godebug) n
-> _, err = fixImports(fileSet, file, filename)
(godebug) s
-> refs := make(map[string]map[string]bool)
(godebug) n
-> decls := make(map[string]*ast.ImportSpec)
(godebug) n
-> abs, err := filepath.Abs(filename)
(godebug) n
-> if err != nil {
(godebug) p err.Error()
"The filename, directory name, or volume label syntax is incorrect."
(godebug) p filename
""
```