### PR TITLE
Allow user to specify the full name of the interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ func (f *File) Close() error {
 	panic("not implemented")
 }
 
+# or provide a full name by specifying the namespace
+impl 'ts *Source' golang.org/x/oauth2.TokenSource
+func (ts *Source) Token() (*oauth2.Token, error) {
+    panic("not implemented")
+}
 ```
 
 You can use `impl` from Vim with [vim-go-impl](https://github.com/rhysd/vim-go-impl)

--- a/impl.go
+++ b/impl.go
@@ -40,11 +40,35 @@ func findInterface(iface string) (path string, id string, err error) {
 		return "", "", fmt.Errorf("couldn't parse interface: %s", iface)
 	}
 
-	// Let goimports do the heavy lifting.
-	src := []byte("package hack\n" + "var i " + iface)
-	imp, err := imports.Process(".", src, nil)
-	if err != nil {
-		return "", "", fmt.Errorf("couldn't parse interface: %s", iface)
+	var importPath string
+	liStash := strings.LastIndex(iface, "/")
+	liDot := strings.LastIndex(iface, ".")
+	if liStash > -1 {
+		// make sure iface is not ending with "/" (e.g. reject net/http/)
+		if liStash+1 == len(iface) {
+			return "", "", fmt.Errorf("interface name cannot end with a '/' character: %s", iface)
+		}
+		// make sure iface has a "." after "/" (e.g. reject net/http/httputil)
+		if liDot < liStash {
+			return "", "", fmt.Errorf("invalid interface name: %s", iface)
+		}
+		importPath = iface[:liDot]
+		iface = iface[liStash+1:]
+	}
+
+	var imp []byte
+	if importPath == "" {
+		src := []byte("package hack\n" + "var i " + iface)
+		// If we couldn't determine the import path, goimports will
+		// auto fix the import path.
+		imp, err = imports.Process(".", src, nil)
+		if err != nil {
+			return "", "", fmt.Errorf("couldn't parse interface: %s", iface)
+		}
+	} else {
+		imp = []byte(fmt.Sprintf(`package hack
+		import "%s"
+		var i %s`, importPath, iface))
 	}
 
 	// imp should now contain an appropriate import.


### PR DESCRIPTION
goimports cannot determine which namespace you would like to import
from. Given the following command,

```
$ impl 'c* Conn' driver.Conn
```
it implements the sql/driver.Conn interface even though I would like
to implement golang.org/x/exp/io/spi/driver.Conn.

This CL allows users to specify the namespace to remove ambiguity.

```
$ impl 'c *Conn' golang.org/x/exp/io/spi/driver.Conn
func (c *Conn) Configure(k int, v int) error {
  panic("not implemented")
}

func (c *Conn) Transfer(tx []byte, rx []byte) error {
  panic("not implemented")
}

func (c *Conn) Close() error {
  panic("not implemented")
}
```