### PR TITLE
Fix inverted err == nil check.

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -308,7 +308,7 @@ func main() {
 	}
 
 	if *flagSrcDir == "" {
-		if dir, err := os.Getwd(); err != nil {
+		if dir, err := os.Getwd(); err == nil {
 			*flagSrcDir = dir
 		}
 	}


### PR DESCRIPTION
The body of the if statement is the success case, so it should run when err == nil.

Fixup for https://github.com/josharian/impl/pull/18#discussion_r122519214.