### PR TITLE
Add special case for the built-in error interface

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -215,10 +215,21 @@ func (p Pkg) funcsig(f *ast.Field) Func {
 	return fn
 }
 
+// The error interface is built-in.
+var errorInterface = []Func{{
+	Name: "Error",
+	Res:  []Param{{Type: "string"}},
+}}
+
 // funcs returns the set of methods required to implement iface.
 // It is called funcs rather than methods because the
 // function descriptions are functions; there is no receiver.
 func funcs(iface string, srcDir string) ([]Func, error) {
+	// Special case for the built-in error interface.
+	if iface == "error" {
+		return errorInterface, nil
+	}
+
 	// Locate the interface.
 	path, id, err := findInterface(iface, srcDir)
 	if err != nil {

--- a/impl_test.go
+++ b/impl_test.go
@@ -118,7 +118,7 @@ func TestFuncs(t *testing.T) {
 				},
 				{
 					Name:   "WriteHeader",
-					Params: []Param{{Type: "int"}},
+					Params: []Param{{Type: "int", Name: "statusCode"}},
 				},
 			},
 		},
@@ -174,6 +174,15 @@ func TestFuncs(t *testing.T) {
 						{Name: "additionalData", Type: "[]byte"},
 					},
 					Res: []Param{{Type: "[]byte"}, {Type: "error"}},
+				},
+			},
+		},
+		{
+			iface: "error",
+			want: []Func{
+				{
+					Name: "Error",
+					Res:  []Param{{Type: "string"}},
 				},
 			},
 		},


### PR DESCRIPTION
`error` is Go's only predeclared type, and can't be resolved using the
regular ast traversal. So attempting to use `impl` to add the `error`
interface would error out.

https://golang.org/ref/spec#Errors