### PR TITLE
Add TODO comment to "not implemented" panic line

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -293,7 +293,7 @@ const stub = "{{if .Comments}}{{.Comments}}{{end}}" +
 	"func ({{.Recv}}) {{.Name}}" +
 	"({{range .Params}}{{.Name}} {{.Type}}, {{end}})" +
 	"({{range .Res}}{{.Name}} {{.Type}}, {{end}})" +
-	"{\n" + "panic(\"not implemented\")" + "}\n\n"
+	"{\n" + "panic(\"not implemented\") // TODO: Implement" + "}\n\n"
 
 var tmpl = template.Must(template.New("test").Parse(stub))
 


### PR DESCRIPTION
TODO comments can be highlighted by IDEs (some native, some with extensions) or even collected into a task list by some. So adding this line by default to each "not implemented" panic line can help keeping an overview of the functions that still need to be implemented.

Closes #31