### PR TITLE
fix TODO: Implement

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -293,7 +293,7 @@ const stub = "{{if .Comments}}{{.Comments}}{{end}}" +
 	"func ({{.Recv}}) {{.Name}}" +
 	"({{range .Params}}{{.Name}} {{.Type}}, {{end}})" +
 	"({{range .Res}}{{.Name}} {{.Type}}, {{end}})" +
-	"{\n" + "panic(\"not implemented\") // TODO: Implement" + "}\n\n"
+	"{\n" + "panic(\"not implemented\") // TODO: Implement" + "\n}\n\n"
 
 var tmpl = template.Must(template.New("test").Parse(stub))
 


### PR DESCRIPTION
I updated to the latest version, and found there was panic when impl a struct.

``` 
panic: 4:33: expected operand, found ']' (and 1 more errors)

goroutine 1 [running]:
main.genStubs(0x7ffeefbff4ad, 0xf, 0xc0000c08c0, 0x3, 0x4, 0x3, 0x4, 0x0)
        /Users/happyleaf/Documents/work/gocode/src/github.com/josharian/impl/impl.go:314 +0x357
main.main()
        /Users/happyleaf/Documents/work/gocode/src/github.com/josharian/impl/impl.go:392 +0x1ac
```

this pull request is my fix.