### PR TITLE
impl: also search Cgofiles

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -118,7 +118,10 @@ func typeSpec(path string, id string, srcDir string) (Pkg, Spec, error) {
 	}
 
 	fset := token.NewFileSet() // share one fset across the whole package
-	for _, file := range pkg.GoFiles {
+	var files []string
+	files = append(files, pkg.GoFiles...)
+	files = append(files, pkg.CgoFiles...)
+	for _, file := range files {
 		f, err := parser.ParseFile(fset, filepath.Join(pkg.Dir, file), nil, parser.ParseComments)
 		if err != nil {
 			continue


### PR DESCRIPTION
cgo files weren't being searched thus anything declared in a go
file with impot c were failing with 

	$ impl 'b *bla' github.com/apple/foundationdb/bindings/go/src/fdb/subspace.Subspace
	interface fdb.KeyConvertible not found: type KeyConvertible not found in github.com/apple/foundationdb/bindings/go/src/fdb

applying this fix, fixes the issue.