### PR TITLE
support unqualified interface names

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -87,7 +87,7 @@ func findInterface(iface string, srcDir string) (path string, id string, err err
 		panic(err)
 	}
 
-	qualified := strings.ContainsRune(iface, '.')
+	qualified := strings.Contains(iface, ".")
 
 	if len(f.Imports) == 0 && qualified {
 		return "", "", fmt.Errorf("unrecognized interface: %s", iface)

--- a/impl_test.go
+++ b/impl_test.go
@@ -533,14 +533,17 @@ func TestStubGeneration(t *testing.T) {
 		{
 			iface: "github.com/josharian/impl/testdata.Interface1",
 			want:  testdata.Interface1Output,
+			dir:   ".",
 		},
 		{
 			iface: "github.com/josharian/impl/testdata.Interface2",
 			want:  testdata.Interface2Output,
+			dir:   ".",
 		},
 		{
 			iface: "github.com/josharian/impl/testdata.Interface3",
 			want:  testdata.Interface3Output,
+			dir:   ".",
 		},
 		{
 			iface: "Interface1",
@@ -549,10 +552,6 @@ func TestStubGeneration(t *testing.T) {
 		},
 	}
 	for _, tt := range cases {
-		if tt.dir == "" {
-			tt.dir = "."
-		}
-
 		fns, err := funcs(tt.iface, tt.dir)
 		if err != nil {
 			t.Errorf("funcs(%q).err=%v", tt.iface, err)

--- a/impl_test.go
+++ b/impl_test.go
@@ -528,6 +528,7 @@ func TestStubGeneration(t *testing.T) {
 	cases := []struct {
 		iface string
 		want  string
+		dir   string
 	}{
 		{
 			iface: "github.com/josharian/impl/testdata.Interface1",
@@ -541,9 +542,18 @@ func TestStubGeneration(t *testing.T) {
 			iface: "github.com/josharian/impl/testdata.Interface3",
 			want:  testdata.Interface3Output,
 		},
+		{
+			iface: "Interface1",
+			want:  testdata.Interface1Output,
+			dir:   "testdata",
+		},
 	}
 	for _, tt := range cases {
-		fns, err := funcs(tt.iface, ".")
+		if tt.dir == "" {
+			tt.dir = "."
+		}
+
+		fns, err := funcs(tt.iface, tt.dir)
 		if err != nil {
 			t.Errorf("funcs(%q).err=%v", tt.iface, err)
 		}


### PR DESCRIPTION
Support unqualified package names as a way to easily specify an
interface from the package in srcDir to be implemented.

Fixes #14 and closes fatih/vim-go#3084

This is similar to #28, but has tests added and is a slightly different implementation.