### PR TITLE
Add flag for disabling copying of comments

### DIFF
--- a/impl_test.go
+++ b/impl_test.go
@@ -87,9 +87,10 @@ func TestTypeSpec(t *testing.T) {
 func TestFuncs(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		iface   string
-		want    []Func
-		wantErr bool
+		iface      string
+		noComments bool
+		want       []Func
+		wantErr    bool
 	}{
 		{
 			iface: "io.ReadWriter",
@@ -216,6 +217,15 @@ func TestFuncs(t *testing.T) {
 			},
 		},
 		{
+			iface:      "http.Flusher",
+			noComments: true,
+			want: []Func{
+				{
+					Name: "Flush",
+				},
+			},
+		},
+		{
 			iface: "net.Listener",
 			want: []Func{
 				{
@@ -239,7 +249,7 @@ func TestFuncs(t *testing.T) {
 		tt := tt
 		t.Run(tt.iface, func(t *testing.T) {
 			t.Parallel()
-			fns, err := funcs(tt.iface, "")
+			fns, err := funcs(tt.iface, "", tt.noComments)
 			gotErr := err != nil
 			if tt.wantErr != gotErr {
 				t.Fatalf("funcs(%q).err=%v want %s", tt.iface, err, errBool(tt.wantErr))
@@ -254,6 +264,9 @@ func TestFuncs(t *testing.T) {
 					!reflect.DeepEqual(fn.Res, tt.want[i].Res) {
 
 					t.Errorf("funcs(%q).fns=\n%v\nwant\n%v\n", tt.iface, fns, tt.want)
+				}
+				if tt.noComments && fn.Comments != "" {
+					t.Errorf("funcs(%q).comments=\n%v\nbut comments disabled\n", tt.iface, fns)
 				}
 			}
 		})
@@ -514,7 +527,7 @@ func TestValidMethodComments(t *testing.T) {
 	}
 
 	for _, tt := range cases {
-		fns, err := funcs(tt.iface, ".")
+		fns, err := funcs(tt.iface, ".", false)
 		if err != nil {
 			t.Errorf("funcs(%q).err=%v", tt.iface, err)
 		}
@@ -552,7 +565,7 @@ func TestStubGeneration(t *testing.T) {
 		},
 	}
 	for _, tt := range cases {
-		fns, err := funcs(tt.iface, tt.dir)
+		fns, err := funcs(tt.iface, tt.dir, false)
 		if err != nil {
 			t.Errorf("funcs(%q).err=%v", tt.iface, err)
 		}
@@ -591,7 +604,7 @@ func TestStubGenerationForImplemented(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.desc, func(t *testing.T) {
-			fns, err := funcs(tt.iface, ".")
+			fns, err := funcs(tt.iface, ".", false)
 			if err != nil {
 				t.Errorf("funcs(%q).err=%v", tt.iface, err)
 			}

--- a/impl_test.go
+++ b/impl_test.go
@@ -87,10 +87,10 @@ func TestTypeSpec(t *testing.T) {
 func TestFuncs(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		iface      string
-		noComments bool
-		want       []Func
-		wantErr    bool
+		iface    string
+		comments EmitComments
+		want     []Func
+		wantErr  bool
 	}{
 		{
 			iface: "io.ReadWriter",
@@ -112,6 +112,7 @@ func TestFuncs(t *testing.T) {
 					},
 				},
 			},
+			comments: WithComments,
 		},
 		{
 			iface: "http.ResponseWriter",
@@ -130,6 +131,7 @@ func TestFuncs(t *testing.T) {
 					Params: []Param{{Type: "int", Name: "statusCode"}},
 				},
 			},
+			comments: WithComments,
 		},
 		{
 			iface: "http.Handler",
@@ -142,6 +144,7 @@ func TestFuncs(t *testing.T) {
 					},
 				},
 			},
+			comments: WithComments,
 		},
 		{
 			iface: "ast.Node",
@@ -155,6 +158,7 @@ func TestFuncs(t *testing.T) {
 					Res:  []Param{{Type: "token.Pos"}},
 				},
 			},
+			comments: WithComments,
 		},
 		{
 			iface: "cipher.AEAD",
@@ -188,6 +192,7 @@ func TestFuncs(t *testing.T) {
 					Res: []Param{{Type: "[]byte"}, {Type: "error"}},
 				},
 			},
+			comments: WithComments,
 		},
 		{
 			iface: "error",
@@ -197,6 +202,7 @@ func TestFuncs(t *testing.T) {
 					Res:  []Param{{Type: "string"}},
 				},
 			},
+			comments: WithComments,
 		},
 		{
 			iface: "error",
@@ -206,6 +212,7 @@ func TestFuncs(t *testing.T) {
 					Res:  []Param{{Type: "string"}},
 				},
 			},
+			comments: WithComments,
 		},
 		{
 			iface: "http.Flusher",
@@ -215,15 +222,16 @@ func TestFuncs(t *testing.T) {
 					Comments: "// Flush sends any buffered data to the client.\n",
 				},
 			},
+			comments: WithComments,
 		},
 		{
-			iface:      "http.Flusher",
-			noComments: true,
+			iface: "http.Flusher",
 			want: []Func{
 				{
 					Name: "Flush",
 				},
 			},
+			comments: WithoutComments,
 		},
 		{
 			iface: "net.Listener",
@@ -241,6 +249,7 @@ func TestFuncs(t *testing.T) {
 					Res:  []Param{{Type: "net.Addr"}},
 				},
 			},
+			comments: WithComments,
 		},
 		{iface: "net.Tennis", wantErr: true},
 	}
@@ -249,7 +258,7 @@ func TestFuncs(t *testing.T) {
 		tt := tt
 		t.Run(tt.iface, func(t *testing.T) {
 			t.Parallel()
-			fns, err := funcs(tt.iface, "", tt.noComments)
+			fns, err := funcs(tt.iface, "", tt.comments)
 			gotErr := err != nil
 			if tt.wantErr != gotErr {
 				t.Fatalf("funcs(%q).err=%v want %s", tt.iface, err, errBool(tt.wantErr))
@@ -265,8 +274,8 @@ func TestFuncs(t *testing.T) {
 
 					t.Errorf("funcs(%q).fns=\n%v\nwant\n%v\n", tt.iface, fns, tt.want)
 				}
-				if tt.noComments && fn.Comments != "" {
-					t.Errorf("funcs(%q).comments=\n%v\nbut comments disabled\n", tt.iface, fns)
+				if tt.comments == WithoutComments && fn.Comments != "" {
+					t.Errorf("funcs(%q).comments=\n%v\nbut comments disabled", tt.iface, fns)
 				}
 			}
 		})
@@ -527,7 +536,7 @@ func TestValidMethodComments(t *testing.T) {
 	}
 
 	for _, tt := range cases {
-		fns, err := funcs(tt.iface, ".", false)
+		fns, err := funcs(tt.iface, ".", WithComments)
 		if err != nil {
 			t.Errorf("funcs(%q).err=%v", tt.iface, err)
 		}
@@ -565,7 +574,7 @@ func TestStubGeneration(t *testing.T) {
 		},
 	}
 	for _, tt := range cases {
-		fns, err := funcs(tt.iface, tt.dir, false)
+		fns, err := funcs(tt.iface, tt.dir, WithComments)
 		if err != nil {
 			t.Errorf("funcs(%q).err=%v", tt.iface, err)
 		}
@@ -604,7 +613,7 @@ func TestStubGenerationForImplemented(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.desc, func(t *testing.T) {
-			fns, err := funcs(tt.iface, ".", false)
+			fns, err := funcs(tt.iface, ".", WithComments)
 			if err != nil {
 				t.Errorf("funcs(%q).err=%v", tt.iface, err)
 			}


### PR DESCRIPTION
Motivation: sometimes I have many implementations of interfaces with huge comments that frequently change, and I would rather point to the authoritative comments than have my comments fall out-of-sync with the interface. Also I usually want to constrain my comments to specifics of the implementation, and not the generalities of the interface.