### PR TITLE
Use `go install` instead of `go get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 `impl` generates method stubs for implementing an interface.
 
 ```bash
-go get -u github.com/josharian/impl
+go install github.com/josharian/impl
 ```
 
 Sample usage:


### PR DESCRIPTION
I couldn't use `impl` on shell with the instructed `go get` command and had to use `go install` instead.