### PR TITLE
filter comments outside of interface declaration (#50)

### DIFF
--- a/impl_test.go
+++ b/impl_test.go
@@ -77,8 +77,8 @@ func TestTypeSpec(t *testing.T) {
 			if reflect.DeepEqual(p, Pkg{}) {
 				t.Errorf("typeSpec(%q, %q).pkg=Pkg{} want non-nil", tt.path, tt.id)
 			}
-			if reflect.DeepEqual(spec, Spec{}) {
-				t.Errorf("typeSpec(%q, %q).spec=Spec{} want non-nil", tt.path, tt.id)
+			if spec == nil {
+				t.Errorf("typeSpec(%q, %q).spec=nil want non-nil", tt.path, tt.id)
 			}
 		}
 	}

--- a/impl_test.go
+++ b/impl_test.go
@@ -572,6 +572,11 @@ func TestStubGeneration(t *testing.T) {
 			want:  testdata.Interface1Output,
 			dir:   "testdata",
 		},
+		{
+			iface: "github.com/josharian/impl/testdata.Interface9",
+			want:  testdata.Interface9Output,
+			dir:   ".",
+		},
 	}
 	for _, tt := range cases {
 		fns, err := funcs(tt.iface, tt.dir, "", WithComments)

--- a/testdata/free_floating.go
+++ b/testdata/free_floating.go
@@ -1,0 +1,25 @@
+package testdata
+
+// Interface9Output is the expected output generated from reflecting on
+// Interface9, provided that the receiver is equal to 'r *Receiver'.
+var Interface9Output = `// Method1 is the first method of Interface1.
+// line two
+func (r *Receiver) Method1(arg1 string, arg2 string) (result string, err error) {
+	panic("not implemented") // TODO: Implement
+}
+
+`
+
+// Interface9 is a dummy interface to test the program output.
+// This interface tests free-floating comments
+type Interface9 interface {
+	// free-floating comment before Method1
+
+	// Method1 is the first method of Interface1.
+	// line two
+	Method1(arg1 string, arg2 string) (result string, err error)
+
+	// free-floating comment after Method1
+}
+
+// free-floating comment at end of file. This must be the last comment in this file.


### PR DESCRIPTION
This is a fix for Issue #50. It works by filtering comments outside of the interface declaration.

Arguably, this could be fixed in the ast package itself, as it's the ast package that assigns a comment at the end of the file to the last parsed node, but maybe that's expected behavior?